### PR TITLE
0.3.1 - Clean Nodes

### DIFF
--- a/gatsby-theme-github-stats/CHANGELOG.md
+++ b/gatsby-theme-github-stats/CHANGELOG.md
@@ -1,13 +1,18 @@
+# 0.3.1 - July 14, 2019
+
+- fix: Drastically lowered html node count by removing dots from graphs
+- fix: Turned off graph rendering animations
+
 # 0.3.0 - July 10, 2019
 
-- feat: added additional stats for each metric
+- feat: Added additional stats for each metric
 
 # 0.2.0 - July 06, 2019
 
-- feat: add theme-ui to start theme API for customizing page style
+- feat: Add theme-ui to start theme API for customizing page style
 - fix: Creating tokens in siteMetadata for header & footers.
-- feat: abstracted header, footer, and overview section to components
-- chore: localized numerical values in overview to include commas for better readability
+- feat: Abstracted header, footer, and overview section to components
+- chore: Localized numerical values in overview to include commas for better readability
 
 # 0.1.0 - July 03, 2019
 

--- a/gatsby-theme-github-stats/package.json
+++ b/gatsby-theme-github-stats/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-theme-github-stats",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "index.js",
   "license": "MIT",
   "author": {

--- a/gatsby-theme-github-stats/src/components/StatChart.js
+++ b/gatsby-theme-github-stats/src/components/StatChart.js
@@ -37,11 +37,8 @@ const StatChart = ({ title, data, yKey, color }) => {
             type="monotone"
             dataKey={yKey}
             stroke={color}
-            dot={{
-              stroke: color,
-              strokeWidth: 1,
-              fill: color,
-            }}
+            dot={false}
+            isAnimationActive={false}
           />
           <XAxis
             dataKey="timestamp"


### PR DESCRIPTION
With Recharts, every datapoints' rendered dot is an individual HTML node, compared to a single node for the lines as they are just paths. This was causing a lot of nodes to be needed to be rendered and redrawn. To mitigate this issue, I removed the dots at each datapoint.

As well, I turned off the animations for now. I may add thing into the theme's options to toggle it at a later point